### PR TITLE
swap ".status" and ".send" order for invalid note in in new_note_spa route

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ router.get('/data.json', (req, res) => {
 
 router.post('/new_note_spa', (req, res) => {
   if (!isValidNote(req.body)) {
-    return res.send('invalid note').status(400)
+    return res.status(400).send('invalid note')
   }
 
   createNote(formatNote(req.body))


### PR DESCRIPTION
In the route /new_note_spa, the response for invalid notes called res.send() before res.status(400),  
which results in HTTP 200 instead of 400.  
This PR swaps the order to res.status(400).send(...) to return the proper status code.
