### PR TITLE
Improve client-server consistency by checking response status before updating locally

### DIFF
--- a/public/spa.js
+++ b/public/spa.js
@@ -33,8 +33,13 @@ xhttp.send()
 var sendToServer = function (note) {
   var xhttpForPost = new XMLHttpRequest()
   xhttpForPost.onreadystatechange = function () {
-    if (this.readyState == 4 && this.status == 201) {
+    if (this.readyState !== 4) return;
+    if (this.status === 201) {
       console.log(this.responseText)
+      notes.push(note)
+      redrawNotes()
+    } else {
+      console.error("Note was not accepted:", this.responseText)
     }
   }
 
@@ -47,15 +52,13 @@ window.onload = function (e) {
   var form = document.getElementById("notes_form")
   form.onsubmit = function (e) {
     e.preventDefault()
-
+  
     var note = {
       content: e.target.elements[0].value,
       date: new Date()
     }
-
-    notes.push(note)
+  
     e.target.elements[0].value = ""
-    redrawNotes()
     sendToServer(note)
   }
 }


### PR DESCRIPTION
Previously, the client assumed notes were accepted as soon as they were added locally (redrawNotes was called immediately after adding the note, regardless of the server response).
This change improves sync by verifying the server responded with status 201 after readyState 4, before pushing to memory and redrawing.
